### PR TITLE
Fix GPU-accelerated PyTorch installation, CMakeLists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ python_src/models/trained
 python_src/*.so
 python_src/.idea
 cmake-build-debug
+*.zip
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,19 +3,16 @@ project(implicit_lidar_network)
 
 
 SET(CMAKE_BUILD_TYPE Release)
-#SET(CMAKE_BUILD_TYPE Debug)
-ADD_COMPILE_OPTIONS(-std=c++11)
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-    ADD_COMPILE_OPTIONS(-O3)
-endif()
+SET(CMAKE_CXX_VERSION 11)
 
-## Find catkin macros and libraries
-find_package(catkin REQUIRED COMPONENTS
-    roscpp
-    rospy
-    sensor_msgs
-    pcl_ros
-)
+if(catkin_FOUND)
+	find_package(catkin REQUIRED COMPONENTS
+    	roscpp
+    	rospy
+    	sensor_msgs
+    	pcl_ros
+	)
+endif()
 
 FIND_PACKAGE(Eigen3 REQUIRED)
 
@@ -26,15 +23,14 @@ if(OPENMP_FOUND)
 endif()
 ADD_DEFINITIONS(-DOPENMP)
 
-
-catkin_package(
-)
-
-include_directories(
-    include
-    ${catkin_INCLUDE_DIRS}
-    ${EIGEN3_INCLUDE_DIR}
-)
+if(catkin_FOUND)
+	catkin_package()
+endif()
+	include_directories(
+    	include
+    	${catkin_INCLUDE_DIRS}
+    	${EIGEN3_INCLUDE_DIR}
+	)
 
 add_subdirectory(extern/pybind11)
 pybind11_add_module(voxelizer SHARED src/voxelizer.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,12 @@ SET(CMAKE_BUILD_TYPE Release)
 SET(CMAKE_CXX_VERSION 11)
 
 if(catkin_FOUND)
-	find_package(catkin REQUIRED COMPONENTS
-    	roscpp
-    	rospy
-    	sensor_msgs
-    	pcl_ros
-	)
+    find_package(catkin REQUIRED COMPONENTS
+        roscpp
+        rospy
+        sensor_msgs
+        pcl_ros
+    )
 endif()
 
 FIND_PACKAGE(Eigen3 REQUIRED)
@@ -24,13 +24,13 @@ endif()
 ADD_DEFINITIONS(-DOPENMP)
 
 if(catkin_FOUND)
-	catkin_package()
+    catkin_package()
 endif()
-	include_directories(
-    	include
-    	${catkin_INCLUDE_DIRS}
-    	${EIGEN3_INCLUDE_DIR}
-	)
+    include_directories(
+        include
+        ${catkin_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIR}
+    )
 
 add_subdirectory(extern/pybind11)
 pybind11_add_module(voxelizer SHARED src/voxelizer.cpp)

--- a/README.md
+++ b/README.md
@@ -56,3 +56,11 @@ You can download the model files from the [link](https://sgvr.kaist.ac.kr/~yskwo
     unzip trained.zip
 
 These commands make the pre-trained models into "python_src/models/trained" where our default model "iln_1d_400.pth" is located.
+
+VISUALIZATION
+-------------
+
+Visualization is supported with ROS in the `implicit_lidar_network` package:
+
+    usage: demo_resolution_free_lidar.py [-h] -i INPUT_FILENAME -cp CHECKPOINT [-v VOXEL_SIZE]
+    demo_resolution_free_lidar.py: error: the following arguments are required: -i/--input_filename, -cp/--checkpoint    

--- a/README.md
+++ b/README.md
@@ -17,19 +17,21 @@ Check the dependencies or install them in your environment using the command:
 
     pip3 install -r python_src/requirements.txt
 
-Our package uses the [Pybind11](https://github.com/pybind/pybind11) library to call several C++ voxelization functions from Python code.
-If you get this project by the "git clone", the Pybind11 source exists in the "extern" directory;
-otherwise you need to set the library manually. 
-Use these commands to build the voxelization module:
+Our package uses the [Pybind11](https://github.com/pybind/pybind11) library to call several C++ voxelization functions from Python code, and is included when cloning with the `--recursive` option: `git clone git@github.com:PinocchioYS/iln.git --recursive`
 
-    mkdir build
-    cd build
-    cmake ..
-    make
+Use these commands to build the voxelization module in a ROS workspace:
 
-You can use the "catkin_make" command if this package is located in the ROS build system.
-The "voxelizer.XXX.so" output file can be found in the "python_src" directory.
+    cd <your_catkin_repo>
+    git clone git@github.com:PinocchioYS/iln.git --recursive src/iln
+    catkin_make 
 
+Use these command to build the voxelization module *outside* or a ROS workspace:
+
+   git clone git@github.com:PinocchioYS/iln.git --recursive
+   mkdir build
+   cd build
+   cmake ..
+   make
 
 CARLA DATASET
 -------------

--- a/python_src/requirements.txt
+++ b/python_src/requirements.txt
@@ -1,8 +1,9 @@
+# https://github.com/pytorch/pytorch/issues/29745#issuecomment-553588171
+--find-links https://download.pytorch.org/whl/cu113/torch_stable.html
+
 einops==0.4.1
 matplotlib==3.5.1
 numpy==1.22.3
 PyYAML==6.0
-rospy==1.15.14
-sensor_msgs==1.13.1
 torch==1.11.0+cu113
 tqdm==4.63.0


### PR DESCRIPTION
A couple changes:

#### Python

* Adds necessary links for pip to find torch gpu version
* remove ROS packages: not installable via pip

#### CMakeLists

* `-O3` is redundant when building in release mode
* Properly set C++ version
* Allow building package in ROS and non-ROS workspace by using `catkin_FOUND` in CMakeLists.txt

#### Misc
* add `build` and `*.zip*` to `.gitignore`
* Update README